### PR TITLE
mux 起動時の tpm 読み込みエラーの解決

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,5 +1,6 @@
 ### tmux plugin manager
 TMUX_PLUGIN_MANAGER_PATH="~/.local/share/tmux/plugins"
+
 ## plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
@@ -12,6 +13,7 @@ set -g @plugin 'catppuccin/tmux'
 if-shell -b '[ "$(uname)" = "Darwin" ]' {
   set -s copy-command "pbcopy"
 }
+
 
 ### my settings
 ## true color
@@ -29,5 +31,8 @@ set -g renumber-windows on
 source "~/.config/tmux/plugins.conf"
 source "~/.config/tmux/keyconfig.conf"
 
+set-environment -g PATH "/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin"
+
 ### load tpm
 run "${TMUX_PLUGIN_MANAGER_PATH}/tpm/tpm"
+


### PR DESCRIPTION
## 概要　
brew で tmux をインストールしている場合、PATHを通してあげる必要がある。
（.zshenv で PATH を通しているが tmux.conf はそれ以前に読み込まれるため、tmux.conf の中で通してあげないといけない。 ）

## ISSUE
close #8 